### PR TITLE
Use current dsworkbench version for dependencies

### DIFF
--- a/ParserPlugin/pom.xml
+++ b/ParserPlugin/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>ParserPlugin</artifactId>
     <name>ParserPlugin</name>
     <packaging>jar</packaging>
-    <version>3.41</version>
+    <version>3.42</version>
 
     <description></description>
     
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>de.tor.dswb</groupId>
             <artifactId>Core</artifactId>
-            <version>3.4</version>
+            <version>3.42</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
The dependencies configuration of the ParserPlugin module was broken
because of using wrong version numbers of dependencies.

Signed-off-by: Akeshihiro <akeshihiro@gmx.net>