### PR TITLE
Rewrite .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,24 @@
-/build/
-/dist/
-/target/
-/core/target/
-/ParserPlugin/target/
-/Core/target/
-/release/
+# Maven
+target/
+
+# Eclipse
+bin/
+.settings/
+.project
+.classpath
+
+# IntelliJ
+out/
+.idea/
+*.iws
+*.iml
+*.ipr
+
+# NetBeans
+nbproject/private/
+build/
+nbbuild/
+dist/
+nbdist/
+nbactions.xml
+.nb-gradle/


### PR DESCRIPTION
The .gitignore file contained only ignore definitions primary for Maven
and NetBeans and also was not structured, so you had to interpret the
ignores.

The .gitignore file has been rewritten. The ignores are grouped by the
tools. Also the ignore definitions are handled recursively.

Groups of files, that are ignore:
- Maven (generated files)
- Eclipse (project files and generated files)
- IntelliJ (project files and generated files)
- NetBeans (project files and generated files)

Signed-off-by: Akeshihiro <akeshihiro@gmx.net>