### PR TITLE
Make the artefact ids lowercase

### DIFF
--- a/Core/pom.xml
+++ b/Core/pom.xml
@@ -3,12 +3,12 @@
    
     <parent>
         <groupId>de.tor.dswb</groupId>
-        <artifactId>DSWorkbench</artifactId>
+        <artifactId>dsworkbench</artifactId>
         <version>3.42</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.tor.dswb</groupId>
-    <artifactId>Core</artifactId>
+    <artifactId>core</artifactId>
     <name>Core</name>
     <packaging>jar</packaging>
     <version>3.42</version>

--- a/ParserPlugin/pom.xml
+++ b/ParserPlugin/pom.xml
@@ -2,12 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <groupId>de.tor.dswb</groupId>
-        <artifactId>DSWorkbench</artifactId>
+        <artifactId>dsworkbench</artifactId>
         <version>3.42</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.tor.dswb</groupId>
-    <artifactId>ParserPlugin</artifactId>
+    <artifactId>parserplugin</artifactId>
     <name>ParserPlugin</name>
     <packaging>jar</packaging>
     <version>3.41</version>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.tor.dswb</groupId>
-    <artifactId>DSWorkbench</artifactId>
+    <artifactId>dsworkbench</artifactId>
     <name>DSWorkbench</name>
     <packaging>pom</packaging>
     <version>3.42</version>


### PR DESCRIPTION
Generally the artefact ids are written in lowercase, so the artefact
ids have been changed by that convention.

Signed-off-by: Akeshihiro <akeshihiro@gmx.net>