### PR TITLE
Update show.tmpl

### DIFF
--- a/resources/Scripts/show.tmpl
+++ b/resources/Scripts/show.tmpl
@@ -3,12 +3,12 @@
 // @description    DS Workbench Attack Info Script
 // @author 		   Torridity
 // @namespace 	   http://www.dsworkbench.de/
-// @include        http://de*.die-staemme.de/game.php?*screen=overview*
-// @include        http://de*.die-staemme.de/game.php?*screen=place*
-// @include        http://de*.die-staemme.de/game.php?*screen=info_village*
-// @include        http://zz*.tribalwars.net/game.php?*screen=overview*
-// @include        http://zz*.tribalwars.net/game.php?*screen=place*
-// @include        http://zz*.tribalwars.net/game.php?*screen=info_village*
+// @include        https://de*.die-staemme.de/game.php?*screen=overview*
+// @include        https://de*.die-staemme.de/game.php?*screen=place*
+// @include        https://de*.die-staemme.de/game.php?*screen=info_village*
+// @include        https://zz*.tribalwars.net/game.php?*screen=overview*
+// @include        https://zz*.tribalwars.net/game.php?*screen=place*
+// @include        https://zz*.tribalwars.net/game.php?*screen=info_village*
 // ==/UserScript==
 
 var win = window.opera ? window:unsafeWindow;


### PR DESCRIPTION
Durch Anpassung der URL-Struktur von DS sind die Includes ins leere gelaufen. Gleichzeitig müsste durch Innogames das Userscript unter http://scripts.die-staemme.de/gm-scripts/wb_attack_info.js angepasst werden.