### PR TITLE
Import dynamische gruppen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist/
 nbdist/
 nbactions.xml
 .nb-gradle/
+
+# General
+release/

--- a/Core/src/main/java/de/tor/tribes/ui/windows/DSWorkbenchMainFrame.java
+++ b/Core/src/main/java/de/tor/tribes/ui/windows/DSWorkbenchMainFrame.java
@@ -2964,29 +2964,47 @@ private void fireChangeClipboardWatchEvent(java.awt.event.MouseEvent evt) {//GEN
     String[] groups = pParserResult.keySet().toArray(new String[]{});
     //NotifierFrame.doNotification("DS Workbench hat " + groups.length + ((groups.length == 1) ? " Dorfgruppe " : " Dorfgruppen ") + "in der Zwischenablage gefunden.", NotifierFrame.NOTIFY_INFO);
     showSuccess("DS Workbench hat " + groups.length + ((groups.length == 1) ? " Dorfgruppe " : " Dorfgruppen ") + "in der Zwischenablage gefunden.");
-    //remove all tags
-    for (String group : groups) {
-      List<Village> villagesForGroup = pParserResult.get(group);
-      if (villagesForGroup != null) {
-        for (Village v : villagesForGroup) {
-          TagManager.getSingleton().removeTags(v);
-        }
-      }
-    }
-
-    for (String group : groups) {
-      //add new groups
-      TagManager.getSingleton().addTagFast(group);
-      //get (added) group
-      Tag t = TagManager.getSingleton().getTagByName(group);
-      //add villages to group
-      List<Village> villagesForGroup = pParserResult.get(group);
-      if (villagesForGroup != null) {
-        //set new tags
-        for (Village v : villagesForGroup) {
-          t.tagVillage(v.getId());
-        }
-      }
+    if(groups.length!=1){ // Data from group import (all groups for given villages)
+	    //remove all tags
+	    for (String group : groups) {
+	      List<Village> villagesForGroup = pParserResult.get(group);
+	      if (villagesForGroup != null) {
+	        for (Village v : villagesForGroup) {
+	          TagManager.getSingleton().removeTags(v);
+	        }
+	      }
+	    }
+	
+	    for (String group : groups) {
+	      //add new groups
+	      TagManager.getSingleton().addTagFast(group);
+	      //get (added) group
+	      Tag t = TagManager.getSingleton().getTagByName(group);
+	      //add villages to group
+	      List<Village> villagesForGroup = pParserResult.get(group);
+	      if (villagesForGroup != null) {
+	        //set new tags
+	        for (Village v : villagesForGroup) {
+	          t.tagVillage(v.getId());
+	        }
+	      }
+	    }
+    } else { // data from troops import (all villages for given group) 
+    	for (String group : groups) {
+	      //add new groups
+	      TagManager.getSingleton().addTagFast(group);
+	      //get (added) group
+	      Tag t = TagManager.getSingleton().getTagByName(group);
+	      t.clearTaggedVillages();
+	      //add villages to group
+	      List<Village> villagesForGroup = pParserResult.get(group);
+	      if (villagesForGroup != null) {
+	        //set new tags
+	        for (Village v : villagesForGroup) {
+	          t.tagVillage(v.getId());
+	        }
+	      }
+	    }    	
     }
     TagManager.getSingleton().revalidate(true);
   }

--- a/ParserPlugin/src/main/java/de/tor/tribes/util/parser/GroupParser.java
+++ b/ParserPlugin/src/main/java/de/tor/tribes/util/parser/GroupParser.java
@@ -57,9 +57,9 @@ public class GroupParser implements SilentParserInterface {
         try {
             JSONObject sectorObject = new JSONObject(pData);
             JSONObject data = (JSONObject) sectorObject.get("id");
-            Iterator keys = data.keys();
+            Iterator<String> keys = data.keys();
             while (keys.hasNext()) {
-                String villageId = (String) keys.next();
+                String villageId = keys.next();
                 String groupName = (String) data.get(villageId);
 
                 List<Village> groups = mappings.get(groupName);
@@ -83,7 +83,7 @@ public class GroupParser implements SilentParserInterface {
     }
 
     public boolean parse(String pGroupsString) {
-
+    	
         if (parseVillageRenamerData(pGroupsString)) {
             return true;
         }

--- a/ParserPlugin/src/main/java/de/tor/tribes/util/parser/ParserVariableManager.java
+++ b/ParserPlugin/src/main/java/de/tor/tribes/util/parser/ParserVariableManager.java
@@ -68,6 +68,8 @@ public class ParserVariableManager {
         DEFAULT.put("de.sos.date.format", "dd.MM.yy HH:mm:ss");
         DEFAULT.put("de.sos.date.format.ms", "dd.MM.yy HH:mm:ss:SSS");
         DEFAULT.put("de.sos.troops.in.village", "Anwesende Truppen");
+        DEFAULT.put("de.overview.groups", "Gruppen:");
+        DEFAULT.put("de.groups.all", "alle");
     }
 
     public String getProperty(String pProperty) {

--- a/resources/templates/parser.properties
+++ b/resources/templates/parser.properties
@@ -8,6 +8,7 @@ de.troops.place.overall=Insgesamt
 de.troops.place.in.other.villages=Truppen in anderen Dörfern
 de.troops.commands=Befehle
 de.troops=Truppen
+de.groups.all=alle
 de.groups.edit=bearbeiten
 de.attack.arrive.time=Ankunft:
 de.sos.defender=Verteidiger
@@ -19,6 +20,7 @@ de.sos.date.format=dd.MM.yy HH:mm:ss
 de.sos.date.format.ms=dd.MM.yy HH:mm:ss:SSS
 de.sos.wall.level=Stufe des Walls:
 de.sos.troops.in.village=Anwesende Truppen
+de.overview.groups=Gruppen:
 
 #variables for suisse servers
 ch.troops.own=eigeni
@@ -30,6 +32,7 @@ ch.troops.place.overall=Insgesamt
 ch.troops.place.in.other.villages=Truppen in anderen Dörfern
 ch.troops.commands=Befäu
 ch.troops=Truppe
+ch.groups.all=???
 ch.groups.edit=bearbeite
 ch.attack.arrive.time=???
 ch.sos.defender=???
@@ -41,6 +44,7 @@ ch.sos.date.format=dd.MM.yy HH:mm:ss
 ch.sos.date.format.ms=dd.MM.yy HH:mm:ss:SSS
 ch.sos.wall.level=???
 ch.sos.troops.in.village=???
+ch.overview.groups=???
 
 #variables for french servers
 fr.troops.own=le tien
@@ -52,6 +56,7 @@ fr.troops=Troupes
 fr.troops.place.from.village=De ce village
 fr.troops.place.overall=Total
 fr.troops.place.in.other.villages=Les troupes dans les autres villages
+fr.groups.all=???
 fr.groups.edit=éditer
 fr.attack.arrive.time=???
 fr.sos.defender=Défenseur
@@ -63,6 +68,7 @@ fr.sos.source=Origine:
 fr.sos.arrive.time=Heure d'arrivée:
 fr.sos.date.format=dd/MM/yy HH:mm:ss
 fr.sos.date.format.ms=dd/MM/yy HH:mm:ss:SSS
+fr.overview.groups=???
 
 #default variables for english servers
 en.troops.own=your own
@@ -74,6 +80,7 @@ en.troops.place.overall=Total
 en.troops.place.in.other.villages=Troops in other villages
 en.troops.commands=	Commands
 en.troops=Troops
+en.groups.all=???
 en.groups.edit=edit
 en.attack.arrive.time=Arrival:
 en.sos.defender=Defender
@@ -85,3 +92,4 @@ en.sos.date.format=MMM dd, yyyy HH:mm:ss
 en.sos.date.format.ms=MMM dd, yyyy HH:mm:ss:SSS
 en.sos.wall.level=Level of the wall:
 en.sos.troops.in.village=Residing troops
+en.overview.groups=???


### PR DESCRIPTION
Ich habe ingame einen Haufen dynamischer Gruppen (z.B. "volle Offensive"), die ich gerne in DS-Workbench importieren möchte. Da der Gruppenimport ja nur für manuelle Gruppen funktioniert halte ich diese Lösung für praktisch: Wird beim Truppenimport nicht "alle", sondern eine Gruppe ausgewählt, so wird diese als Gruppe importiert. 

Getestet auf de124. TroopsParser ist auch geändert, allerdings nicht getestet (da TroopsParser70 ausgeführt wird). 

ToDo: in parser.properties andere Sprachversionen eintragen. 