### PR TITLE
Diplomacy Parser, 4k Fix

### DIFF
--- a/Core/src/main/java/de/tor/tribes/ui/RibbonConfigurator.java
+++ b/Core/src/main/java/de/tor/tribes/ui/RibbonConfigurator.java
@@ -71,8 +71,11 @@ import org.pushingpixels.flamingo.api.ribbon.RibbonApplicationMenuEntryFooter;
 import org.pushingpixels.flamingo.api.ribbon.RibbonApplicationMenuEntryPrimary;
 import org.pushingpixels.flamingo.api.ribbon.RibbonElementPriority;
 import org.pushingpixels.flamingo.api.ribbon.RibbonTask;
+import org.pushingpixels.flamingo.api.ribbon.resize.BaseRibbonBandResizePolicy;
 import org.pushingpixels.flamingo.api.ribbon.resize.CoreRibbonResizePolicies;
 import org.pushingpixels.flamingo.api.ribbon.resize.IconRibbonBandResizePolicy;
+import org.pushingpixels.flamingo.api.ribbon.resize.RibbonBandResizePolicy;
+import org.pushingpixels.flamingo.internal.ui.ribbon.AbstractBandControlPanel;
 
 /**
  * @author Torridity
@@ -426,11 +429,11 @@ public class RibbonConfigurator {
 
         infoViewBand.setResizePolicies((List) Arrays.asList(
                 new CoreRibbonResizePolicies.Mirror(infoViewBand.getControlPanel()),
-                new CoreRibbonResizePolicies.Mid2Low(infoViewBand.getControlPanel()),
+                // new CoreRibbonResizePolicies.Mid2Low(infoViewBand.getControlPanel()),
                 new IconRibbonBandResizePolicy(infoViewBand.getControlPanel())));
         attackViewBand.setResizePolicies((List) Arrays.asList(
                 new CoreRibbonResizePolicies.Mirror(attackViewBand.getControlPanel()),
-                new CoreRibbonResizePolicies.Mid2Low(attackViewBand.getControlPanel()),
+                // new CoreRibbonResizePolicies.Mid2Low(attackViewBand.getControlPanel()),
                 new IconRibbonBandResizePolicy(attackViewBand.getControlPanel())));
         ingameInfoViewBand.setResizePolicies((List) Arrays.asList(
                 new CoreRibbonResizePolicies.None(ingameInfoViewBand.getControlPanel()),
@@ -1089,7 +1092,8 @@ public class RibbonConfigurator {
         miscBand.addCommandButton(aboutButton, RibbonElementPriority.TOP);
 
         miscBand.setResizePolicies((List) Arrays.asList(
-                new CoreRibbonResizePolicies.None(miscBand.getControlPanel()) 
+                new CoreRibbonResizePolicies.None(miscBand.getControlPanel()),
+                new IconRibbonBandResizePolicy(miscBand.getControlPanel())
                 ));
         RibbonTask task1 = new RibbonTask("Sonstiges", miscBand);
         frame.getRibbon().addTask(task1);

--- a/Core/src/main/java/de/tor/tribes/ui/panels/MarkerTableTab.java
+++ b/Core/src/main/java/de/tor/tribes/ui/panels/MarkerTableTab.java
@@ -327,9 +327,11 @@ public class MarkerTableTab extends javax.swing.JPanel implements ListSelectionL
             case CUT_TO_INTERNAL_CLIPBOARD:
                 cutToClipboard();
                 break;
+                /*
             case FROM_EXTERNAL_CLIPBOARD:
                 pasteFromExternalClipboard();
                 break;
+                */
             case CLIPBOARD_BB:
                 copyBBToExternalClipboardEvent();
                 break;
@@ -371,10 +373,16 @@ public class MarkerTableTab extends javax.swing.JPanel implements ListSelectionL
         }
     }
 
+    /*
+     * Changed DiplomacyParser from GenericParserInterface to SilentParserInterface, causing errors in this method.
+     * This kind of stuff ist done via ClipboardWatch, PluginManager, DiplomacyParser, MarkerManager now (importing nap/enemy/bnd marker)
+     * Perhaps this whole class is not needed anymore, but i'll leave it in case i'm wrong. 
+     * 
     private void pasteFromExternalClipboard() {
         try {
             String data = (String) Toolkit.getDefaultToolkit().getSystemClipboard().getContents(null).getTransferData(DataFlavor.stringFlavor);
             List<Marker> markers = PluginManager.getSingleton().executeDiplomacyParser(data);
+            
             if (markers.isEmpty()) {
                 //do internal paste
                 copyFromInternalClipboard();
@@ -395,6 +403,7 @@ public class MarkerTableTab extends javax.swing.JPanel implements ListSelectionL
         markerModel.fireTableDataChanged();
         MarkerManager.getSingleton().revalidate(getMarkerSet(), true);
     }
+    */
 
     private void copyFromInternalClipboard() {
         try {

--- a/Core/src/main/java/de/tor/tribes/util/ClipboardWatch.java
+++ b/Core/src/main/java/de/tor/tribes/util/ClipboardWatch.java
@@ -131,6 +131,11 @@ public class ClipboardWatch extends Thread {
                             SystrayHelper.showInfoMessage("Truppen aus Versammlungsplatz erfolgreich eingelesen");
                             playNotification();
                             validData = true;
+                        } else if (PluginManager.getSingleton().executeDiplomacyParser(data)) {
+                            logger.info("Diplomacy info successfully parsed.");
+                            SystrayHelper.showInfoMessage("Kartenmarkierungen aus Diplomatie erfolgreich eingelesen");
+                            playNotification();
+                            validData = true;
                         }
                     }
                     if (validData) {

--- a/Core/src/main/java/de/tor/tribes/util/PluginManager.java
+++ b/Core/src/main/java/de/tor/tribes/util/PluginManager.java
@@ -100,14 +100,15 @@ public class PluginManager {
     return new LinkedList<VillageMerchantInfo>();
   }
 
-  public List<Marker> executeDiplomacyParser(String pData) {
+  public boolean executeDiplomacyParser(String pData) {
     try {
       Object parser = loadParser("de.tor.tribes.util.parser.DiplomacyParser");
-      return ((GenericParserInterface<Marker>) parser).parse(pData);
+      return ((SilentParserInterface) parser).parse(pData);
     } catch (Exception e) {
       logger.error("Failed to execute diplomacy parser", e);
     }
-    return new LinkedList<Marker>();
+    logger.info("Diplomacy parser returned no result");
+    return false;
   }
 
   public boolean executeSupportParser(String pData) {

--- a/ParserPlugin/src/main/java/de/tor/tribes/util/parser/DiplomacyParser.java
+++ b/ParserPlugin/src/main/java/de/tor/tribes/util/parser/DiplomacyParser.java
@@ -20,6 +20,9 @@ import de.tor.tribes.types.ext.Ally;
 import de.tor.tribes.types.Marker;
 import de.tor.tribes.util.Constants;
 import de.tor.tribes.util.GenericParserInterface;
+import de.tor.tribes.util.SilentParserInterface;
+import de.tor.tribes.util.mark.MarkerManager;
+
 import java.awt.Color;
 import java.awt.Toolkit;
 import java.awt.datatransfer.DataFlavor;
@@ -30,50 +33,16 @@ import java.util.StringTokenizer;
 
 /**
  *
+ * @author Patrick
  * @author Torridity
  */
-public class DiplomacyParser implements GenericParserInterface<Marker> {
+public class DiplomacyParser implements SilentParserInterface {
 
-    /**de29
-    Verbündete
-    ~DPG~
-    SAWÜ6
-    OMS
-    Nicht-Angriffs-Pakt (NAP)
-    SAW
-    Feinde
-    +AR+
-    DKGD
-    A-T-A
-    -WZ-
-     *BC*
-    Knight
-    ~LoW~
-    N.O.D.
-    ~DN~
-    nod-J
-    nod-OB
-    Clan
-    -WP-
-    [M]
-    STK
-    ANSI
-    PUNCH!
-    MW
-    bzsz
-     */
-    /**en0
-    Verbündete
-    ~B~B~ 	terminate
-    Nicht-Angriffs-Pakt (NAP)
-    K54 	terminate
-    Enemies
-    
-     */
     private final boolean DEBUG = false;
 
-    public List<Marker> parse(String pData) {
-
+    public boolean parse(String pData) {
+    	// TODO: Sprachabhängige Version von "Verbündete", "Nicht-Angriffs-Pakt (NAP)", "Feinde" aus ParserVariableManager.getSingleton().getProperty() laden
+    	
         StringTokenizer lineTok = new StringTokenizer(pData, "\n\r");
         List<Marker> markers = new ArrayList<Marker>();
         boolean allies = false;
@@ -122,7 +91,12 @@ public class DiplomacyParser implements GenericParserInterface<Marker> {
             }
         }
 
-        return markers;
+        if(markers.isEmpty())return false;
+        
+		for(Marker mark : markers) MarkerManager.getSingleton().addManagedElement(mark);
+		
+		return true;
+        
     }
 
     private Marker getMarkerFromLine(String pLine, Color pMarkerColor) {


### PR DESCRIPTION
Der Diplomacy Parser tut wieder was er soll (Kartenmarkierungen anhand Strg+C der Stammesdiplomatie erstellen), und unter 4k Auflösung sind alle Menüs vorhanden.

Ich habe beim besten Willen keinen Versuch unternommen die 1148 Zeilen des RibbonConfigurator zu verstehen (oder auch nur zu lesen), aber Pattern-Matching nach dem Motto: "Welche Menüs funktionieren, welche Menüs funktionieren nicht" hat ausgereicht um den Fehler zu beheben. Ich hoffe, ich habe dabei nix kaputt gemacht. 

Fix #22 