### PR TITLE
[Security] Update to safe version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,12 +44,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.13.3</version>
+            <version>2.15.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.13.3</version>
+            <version>2.15.1</version>
         </dependency>
         <dependency><!--dependency for log4j-->
             <groupId>xerces</groupId>


### PR DESCRIPTION
This removes any potential for exploitation of CVE-2021-44228.